### PR TITLE
fix(docs): graph_pooling

### DIFF
--- a/examples/ogb/ogbg_mol/README.md
+++ b/examples/ogb/ogbg_mol/README.md
@@ -16,7 +16,7 @@ The code is shared by two molecular datasets: ogbg_molhiv and ogbg_molpcba.
     --epochs 300
     --lr 0.01
 	--dropout 0.5
-	--graph_pooling mean  #options: [mean, max, add]
+	--graph_pooling mean  #options: [mean, max, sum]
 ## ogbg_molhiv: DyResGEN
 ### Train
 	python main.py --use_gpu --conv_encode_edge --num_layers 7 --dataset ogbg-molhiv --block res+ --gcn_aggr softmax --t 1.0 --learn_t --dropout 0.2


### PR DESCRIPTION
Just a small fix. Based on https://github.com/lightaime/deep_gcns_torch/blob/660a488e8be8a207f1f835e01630d254ae91bae7/examples/ogb/ogbg_ppa/model.py#L71-L71
The option is "sum".